### PR TITLE
fix: reorder compare option colors to avoid clash with recommended

### DIFF
--- a/tags/compare.js
+++ b/tags/compare.js
@@ -21,7 +21,7 @@ module.exports = function(hexo) {
     const title = args[0] || '';
     const emoji = args[1] || '';
     const recommended = args.indexOf('recommended') > -1;
-    const colors = [cw.c3, cw.c2, cw.c1, cw.c4];
+    const colors = [cw.c4, cw.c2, cw.c1, cw.c3];
     const color = recommended ? cw.c3 : colors[optionIndex % colors.length];
     const bg = tint(color, 0.08);
     optionIndex++;


### PR DESCRIPTION
## Problem

In the `compare` tag, the recommended option always uses `c3` for its border/accent color. However, the normal option color array started with `c3` as well (`[c3, c2, c1, c4]`), so when the first option is normal and the second is recommended, they end up with nearly identical background colors.

## Fix

Reorder the normal option color array to `[c4, c2, c1, c3]` so the first normal option uses `c4` instead of `c3`. This ensures clear visual distinction between normal and recommended options across all 5 colorways.

The recommended option still uses `c3` — only the normal rotation order changed.

Fixes #1